### PR TITLE
Remove unused imap_tools.Q alias dropped in last release of imap-tools

### DIFF
--- a/mail2gg/__init__.py
+++ b/mail2gg/__init__.py
@@ -9,7 +9,7 @@ from apiclient import discovery
 from oauth2client import client, tools
 from oauth2client.file import Storage
 
-from imap_tools import MailBox, Q
+from imap_tools import MailBox
 from tqdm import tqdm
 
 


### PR DESCRIPTION
Hi,

first of all, many thanks for taking the time to package the original gist into a proper Python module and distribute it on PyPI.

While trying to run `mbox2gg`, I found the command is broken following the latest version of `imap_tools` released yesterday wgucg dropped the `imap_tools.Q` alias - see https://github.com/ikvk/imap_tools/blob/master/release_notes.rst#0170. Since this alias is unused in the current version, I assumed removing its import should not be an issue.