### PR TITLE
Enforce imap_tools 0.30.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 httplib2
 oauth2client
-imap-tools
+imap-tools==0.30.0
 google-api-python-client
 fire
 tqdm


### PR DESCRIPTION
Related with #3, new versions of `imap_tools` deprecates the `query.Q` API